### PR TITLE
Changed kernel version for 'TCP_SEQ_STATE_OPENREQ'

### DIFF
--- a/knetstat.c
+++ b/knetstat.c
@@ -125,7 +125,7 @@ static int tcp_seq_show(struct seq_file *seq, void *v) {
 				}
 				break;
 			}
-			#if LINUX_VERSION_CODE < KERNEL_VERSION(4,5,0)
+			#if LINUX_VERSION_CODE < KERNEL_VERSION(4,4,0)
 			case TCP_SEQ_STATE_OPENREQ: {
 				const struct inet_request_sock *ireq = inet_rsk(v);
 


### PR DESCRIPTION
@veithen 
When I try to build the module for following distros and kernel versions:
- Ubuntu 16.04, 4.4.0-67-generic
- Ubuntu 14.04, 4.4.0-66-generic

I get this error:

```
DKMS make.log for knetstat-0.5 for kernel 4.4.0-66-generic (x86_64)
Fri Mar 24 08:19:08 UTC 2017
make: Entering directory `/var/lib/dkms/knetstat/0.5/build'
make -C /lib/modules/4.4.0-66-generic/build M=/var/lib/dkms/knetstat/0.5/build modules
make[1]: Entering directory `/usr/src/linux-headers-4.4.0-66-generic'
  CC [M]  /var/lib/dkms/knetstat/0.5/build/knetstat.o
/var/lib/dkms/knetstat/0.5/build/knetstat.c: In function ‘tcp_seq_show’:
/var/lib/dkms/knetstat/0.5/build/knetstat.c:129:9: error: ‘TCP_SEQ_STATE_OPENREQ’ undeclared (first use in this function)
    case TCP_SEQ_STATE_OPENREQ: {
         ^
/var/lib/dkms/knetstat/0.5/build/knetstat.c:129:9: note: each undeclared identifier is reported only once for each function it appears in
make[2]: *** [/var/lib/dkms/knetstat/0.5/build/knetstat.o] Error 1
make[1]: *** [_module_/var/lib/dkms/knetstat/0.5/build] Error 2
make[1]: Leaving directory `/usr/src/linux-headers-4.4.0-66-generic'
make: *** [all] Error 2
make: Leaving directory `/var/lib/dkms/knetstat/0.5/build'
```
