### PR TITLE
Add TCP keepalive socket options support

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,13 @@ Currently supported features
 ----------------------------
 
 * Protocols: TCP and UDP (IPv4 and IPv6)
-* Socket options: `SO_REUSEADDR`, `SO_REUSEPORT`, `SO_KEEPALIVE` (TCP), `SO_RCVBUF`, `SO_SNDBUF`, `SO_RCVTIMEO`, `SO_SNDTIMEO`, `SO_LINGER` (TCP), `TCP_NODELAY`, `TCP_FASTOPEN`, `TCP_DEFER_ACCEPT`, `SO_BROADCAST` (UDP)
+* Socket options: `SO_REUSEADDR`, `SO_REUSEPORT`, `SO_KEEPALIVE` (TCP), `TCP_KEEPIDLE` (TCP), `TCP_KEEPCNT` (TCP), `TCP_KEEPINTVL` (TCP), `SO_RCVBUF`, `SO_SNDBUF`, `SO_RCVTIMEO`, `SO_SNDTIMEO`, `SO_LINGER` (TCP), `TCP_NODELAY`, `TCP_FASTOPEN`, `TCP_DEFER_ACCEPT`, `SO_BROADCAST` (UDP)
+
+TCP Keepalive Parameter Handling
+--------------------------------
+
+TCP_KEEPIDLE, TCP_KEEPCNT and TCP_KEEPINTVL correspond to tcp_keepalive_time, tcp_keepalive_probes and tcp_keepalive_intvl values described in tcp(7) and the respective sysctls. If those values are overridden at the socket level (by setting them to something other than zero), they will be printed by knetstat, otherwise, the kernel will use sysctls and the module will ignore them while printing the output.
+
 
 Compatibility
 -------------

--- a/knetstat.c
+++ b/knetstat.c
@@ -230,6 +230,15 @@ static int tcp_seq_show(struct seq_file *seq, void *v) {
 
 
 			seq_printf(seq, "SO_REUSEADDR=%d,SO_REUSEPORT=%d,SO_KEEPALIVE=%d", sk->sk_reuse, sk->sk_reuseport, sock_flag(sk, SOCK_KEEPOPEN));
+                        if (tcp_sk(sk)->keepalive_time > 0) {
+                                seq_printf(seq, ",TCP_KEEPIDLE=%u", tcp_sk(sk)->keepalive_time/HZ);
+                        }
+                        if (tcp_sk(sk)->keepalive_probes > 0) {
+                                seq_printf(seq, ",TCP_KEEPCNT=%u", tcp_sk(sk)->keepalive_probes);
+                        }
+                        if (tcp_sk(sk)->keepalive_intvl > 0) {
+                                seq_printf(seq, ",TCP_KEEPINTVL=%u", tcp_sk(sk)->keepalive_intvl/HZ);
+                        }
 
 			sock_common_options_show(seq, sk);
 


### PR DESCRIPTION
Add support for printing tcp_keepalive_intvl, tcp_keepalive_probes and
tcp_keepalive_time.

keepalive_time and keepalive_intvl have to be divided by HZ as they are
multiplied by that value in the kernel code before being stored:

net/ipv4/tcp.c:

tp->keepalive_time = val * HZ;

tp->keepalive_intvl = val * HZ;

This is quite useful to inspect if an application overrides default
keepalive values somewhere in its code from system defaults which are
usually quite high (2 hours for tcp_keepalive_time by default).

Example:

tcp_keepalive_intvl = 15
tcp_keepalive_probes = 2
tcp_keepalive_time = 15

output:

// ... SO_KEEPALIVE=1,TCP_KEEPIDLE=15,TCP_KEEPCNT=2,TCP_KEEPINTVL=15