### PR TITLE
Fix build failures on newer linux kernels

### DIFF
--- a/knetstat.c
+++ b/knetstat.c
@@ -31,6 +31,12 @@
 
 #include <net/net_namespace.h>
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(3,10,0)
+#define PDE_DATA(i) (PDE(i)->data)
+#elif LINUX_VERSION_CODE >= KERNEL_VERSION(5,14,0)
+#define PDE_DATA(i) pde_data(i)
+#endif
+
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4,13,0)
 #define tcp_time_stamp tcp_time_stamp_raw()
 #endif


### PR DESCRIPTION
This was also reported in some other modules, such as [this](https://github.com/sipwise/rtpengine/commit/b6c0a444f4adb5c9589d7501bae031720dc03889) and a few others.

